### PR TITLE
Add GraphicsEnv.h include guard, expand README, fix COPYRIGHT.md link

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -16,4 +16,4 @@ This notice serves to acknowledge and affirm the authorship of Daniel McCoy Step
 
 ---
 
-For any inquiries regarding licensing, usage, or contributions, please contact Daniel McCoy Stephenson via the official [GitHub repository](https://github.com/Preponderous-Software/sdl-assist).
+For any inquiries regarding licensing, usage, or contributions, please contact Daniel McCoy Stephenson via the official [GitHub repository](https://github.com/Stephenson-Software/sdl-assist).

--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ the event loop so the button can react to the mouse.
 `GraphicsEnv::loadMedia()` opens `objects/bboron.ttf`, a path resolved relative
 to the working directory. That file is not shipped with this repository — the
 font present here is `src/fonts/lazy.ttf` — so the font fails to load unless the
-expected file is supplied. Anything that depends on a loaded font, including the
-`text` and `button` demos, is affected. This is tracked in
-[#7](https://github.com/Stephenson-Software/sdl-assist/issues/7) and
+expected file is supplied. `loadMedia()` responds to the failure by calling
+`cleanUp()`, which destroys the renderer and window mid-run, so the `text` and
+`button` demos crash rather than simply rendering without text. This is tracked
+in [#7](https://github.com/Stephenson-Software/sdl-assist/issues/7),
+[#9](https://github.com/Stephenson-Software/sdl-assist/issues/9) and
 [#10](https://github.com/Stephenson-Software/sdl-assist/issues/10).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,2 +1,125 @@
 # sdl-assist
 This library abstracts out the handling of Simple DirectMedia Layer, providing support for drawing rectangles, text and buttons to the screen.
+
+## Dependencies
+
+A C++ compiler (`g++`) and the SDL2 development packages:
+
+```
+sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
+```
+
+The same three packages are installed by `.devcontainer/Dockerfile` and by the
+build workflow in `.github/workflows/build.yml`, so opening this repository in
+the dev container provides a ready environment.
+
+## Building
+
+There is no library artifact to install. The build compiles the library sources
+together with each demo program:
+
+```
+make -C src/tests all
+```
+
+This produces five executables in `src/tests/`:
+`init_test_executable`, `rectangles_test_executable`, `renderpage_test_executable`,
+`text_test_executable` and `button_test_executable`.
+
+To remove them:
+
+```
+make -C src/tests clean
+```
+
+## Demo programs
+
+Each program under `src/tests/` is a standalone `main()` that opens a real
+window and runs until it receives `SDL_QUIT`, so a display is required to run
+them. Building them does not require a display.
+
+| Target | Source | What it demonstrates |
+|--------|--------|----------------------|
+| `init` | `testInit.cpp` | The minimal lifecycle: a 400x400 window with one black rectangle centered on a white background. |
+| `rectangles` | `testRectangles.cpp` | Animation via `drawRectangle` — a black square moves toward a small green target that relocates to a random position each time it is reached. |
+| `renderpage` | `testRenderPage.cpp` | Layout with rectangles — header, body and footer bands drawn in three shades of blue. |
+| `text` | `testText.cpp` | `Text` rendering — two labels drawn with the font and renderer taken from the environment. |
+| `button` | `testButton.cpp` | `Button` rendering and event handling — clicking the button runs a callback that rewrites a neighbouring `Text` label. |
+
+## Usage
+
+Consuming projects compile the library sources directly alongside their own,
+as `src/tests/Makefile` does:
+
+```
+g++ main.cpp path/to/sdl-assist/src/GraphicsEnv.cpp \
+              path/to/sdl-assist/src/Text.cpp \
+              path/to/sdl-assist/src/Button.cpp \
+              -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -o my_program
+```
+
+A minimal program follows the shape used by every demo:
+
+```cpp
+#include "path/to/sdl-assist/src/header/GraphicsEnv.h"
+
+int main(int argc, char* args[]) {
+	GraphicsEnv environment;
+
+	environment.setTitle("My Program");
+	environment.setScreenWidth(400);
+	environment.setScreenHeight(400);
+
+	environment.init();
+	environment.loadMedia();
+
+	while (environment.isRunning()) {
+		while (environment.pollEvent() != 0) {
+			if (environment.getEvent()->type == SDL_QUIT) {
+				environment.setRunning(false);
+			}
+		}
+
+		environment.setRenderColor(0xFF, 0xFF, 0xFF, 0xFF);
+		environment.clear();
+
+		environment.setRenderColor(0x00, 0x00, 0x00, 0xFF);
+		environment.drawRectangle(environment.getW()/2 - 50, environment.getH()/2 - 50, 100, 100);
+
+		environment.present();
+	}
+
+	environment.cleanUp();
+}
+```
+
+`Text` and `Button` are constructed separately and wired to the environment's
+renderer and font:
+
+```cpp
+SDL_Color textColor = {0x00, 0x00, 0x00, 0xFF};
+
+Text label;
+label.init(25, 25, environment.getFont(), environment.getRenderer(), "Hello", textColor);
+
+Button button;
+button.init(100, 200, 50, 50, environment.getRenderer(), &onMouseDown);
+```
+
+Both are rendered inside the main loop with `label.render()` and
+`button.render()`; `button.handleEvent(environment.getEvent())` is called from
+the event loop so the button can react to the mouse.
+
+## Known limitation
+
+`GraphicsEnv::loadMedia()` opens `objects/bboron.ttf`, a path resolved relative
+to the working directory. That file is not shipped with this repository — the
+font present here is `src/fonts/lazy.ttf` — so the font fails to load unless the
+expected file is supplied. Anything that depends on a loaded font, including the
+`text` and `button` demos, is affected. This is tracked in
+[#7](https://github.com/Stephenson-Software/sdl-assist/issues/7) and
+[#10](https://github.com/Stephenson-Software/sdl-assist/issues/10).
+
+## License
+
+MIT — see [LICENSE](LICENSE) and [COPYRIGHT.md](COPYRIGHT.md).

--- a/src/header/GraphicsEnv.h
+++ b/src/header/GraphicsEnv.h
@@ -1,6 +1,9 @@
 // goal: build a self-contained graphics environment so I don't have to
 //		 do all this stuff every time.
 
+#ifndef GRAPHICSENV_H
+#define GRAPHICSENV_H
+
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 #include <string>
@@ -65,3 +68,5 @@ class GraphicsEnv {
 	
 	std::ofstream log;
 };
+
+#endif


### PR DESCRIPTION
## Summary

Three small, independent hygiene items are addressed:

- **`src/header/GraphicsEnv.h` gains an include guard.** `#ifndef GRAPHICSENV_H` / `#define GRAPHICSENV_H` / `#endif` is added, matching the convention already used by `Text.h` and `Button.h`. Without it, any translation unit that includes the header twice — directly or transitively — fails with a redefinition error. No declaration is added, removed, or changed.
- **`README.md` is expanded** from a title and one sentence into dependencies, build and clean commands, an annotated table of the five demo programs, a usage example, and a known-limitation note. Every claim was traced against the source it describes: the package list against `.devcontainer/Dockerfile` and `.github/workflows/build.yml`, the build and clean commands and the executable names against `src/tests/Makefile`, the per-demo descriptions against each `src/tests/test*.cpp`, and the usage example against `testInit.cpp`, `testText.cpp`, and `testButton.cpp`.
- **`COPYRIGHT.md` is pointed at the current remote.** The inquiry link is updated from `Preponderous-Software/sdl-assist` to `Stephenson-Software/sdl-assist`. Only the URL is touched; no licensing or authorship text is altered.

The README's known-limitation section documents current behavior rather than changing it — `loadMedia()` opens `objects/bboron.ttf`, a file this repository does not ship, which is left to be fixed under #7 and #10.

## Test plan

- [x] `.github/workflows/build.yml` is the build anchor for this PR: the library and all five demo programs are compiled and each executable's presence is asserted. The workflow runs on `pull_request` against `master` and has succeeded on `master`.
- [x] `make -C src/tests all` — not runnable in the session where these changes were written; the SDL2 development headers are absent there (`fatal error: SDL2/SDL_ttf.h: No such file or directory`). The local build is therefore recorded as **UNVERIFIED**, and CI is relied upon as the anchor instead. Since a header is modified, a green CI run is required before this PR is merged.
- [ ] `init`, `rectangles`, `renderpage`, `text`, `button` — builds only. These programs open real SDL windows and loop until `SDL_QUIT`, so none of them was executed. No behavioral or on-screen verification is claimed by this PR.

The change to `GraphicsEnv.h` is purely preprocessor-level and the other two files are documentation, so a green compile of all five demos is the full extent of the verification this change needs; the runtime gap noted above concerns the demos themselves, not anything altered here.

## Merge note

`src/header/*.h` and `COPYRIGHT.md` are both on this loop's do-not-auto-merge list, and no merge authorization was granted for this session. This PR is left open for maintainer review.

## Deferred issues

The remaining open issues were not selected for this cycle:

- **#7** (`loadMedia()` opens a font that is not shipped) and **#10** (`Text::loadText()` dereferences a NULL surface) — both are runtime defects whose fixes cannot be validated headlessly, as the demos that exercise them require a display. These were deferred rather than fixed blind; they are documented in the README instead.
- **#8** (`init()` ignores every SDL and TTF return value), **#9** (`cleanUp()` can run twice, the font is never closed, the log is written after being closed), and **#11** (raw SDL pointers with default copy semantics) — each is a behavior-changing fix to resource lifetime or error handling, which is a poor fit for a cycle batched with documentation and better suited to a dedicated PR with a display-backed smoke test.
- **#14** (public methods never exercised by any demo program) — a demo-expansion cycle in its own right, exceeding the scope appropriate to batch here.

Closes #6
Closes #12
Closes #13

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_
